### PR TITLE
Handle malformed HETATM records during packing

### DIFF
--- a/pypropel/prot/file/Pack.py
+++ b/pypropel/prot/file/Pack.py
@@ -11,8 +11,11 @@ from pypropel.prot.structure.convert.ToFasta import ToFasta
 from pypropel.prot.structure.hetatm.Remove import Remove as hetatmremover
 from pypropel.prot.sequence.IsEmpty import IsEmpty
 from pypropel.prot.sequence.IsMatch import IsMatch
+from pypropel.prot.sequence.Name import Name as chainname
 from pypropel.util.FileIO import FileIO
 from pypropel.util.Console import Console
+import os
+import pandas as pd
 
 
 class Pack:
@@ -36,30 +39,40 @@ class Pack:
     ):
         # ### /* block 1. split into chains */ ###
         self.console.print('=========>++++++++++++++++++++split into chains...\n+++++++++++++++++++++++++++')
+        pdb_cplx_split_fp = self._sanitize_complex_pdbs(
+            pdb_cplx_fp=pdb_cplx_fp,
+            pdb_fp=pdb_fp,
+        )
         Splitter(
             prot_df=self.prot_df,
-            pdb_path=pdb_cplx_fp,
+            pdb_path=pdb_cplx_split_fp,
             sv_fp=pdb_fp,
         ).pdb_per_chain()
+        prot_df = self._filter_existing_split_chains(
+            pdb_fp=pdb_fp,
+        )
+        if prot_df.empty:
+            self.console.print('============>No split-chain PDB files were created; stopping pack.')
+            return 'Finished'
         # ### /* block 2. delete END from PDB files */ ###
         self.console.print('=========>++++++++++++++++++++delete END from PDB files...\n+++++++++++++++++++++++++++')
         FileIO().makedir(pdb_fp + '/delend/')
         Format(
-            prot_df=self.prot_df,
+            prot_df=prot_df,
             sv_fp=pdb_fp + '/delend/',
         ).del_END_frompdb(
             pdb_path=pdb_fp,
         )
         # ### /* block 3. remove hetatm from PDB files */ ###
         self.console.print('=========>++++++++++++++++++++remove hetatm from PDB files...\n+++++++++++++++++++++++++++')
-        hetatmremover(prot_df=self.prot_df).biopython(
+        hetatmremover(prot_df=prot_df).biopython(
             pdb_path=pdb_fp + '/delend/',
             sv_fp=pdb_fp,
         )
         # ### /* block 4. isMatch */ ###
         self.console.print('=========>++++++++++++++++++++is match...\n+++++++++++++++++++++++++++')
         IsMatch(
-            prot_df=self.prot_df,
+            prot_df=prot_df,
             pdb_path=pdb_fp + '/delend/',
             xml_path=xml_fp,
             sv_mismatch_fp=fasta_fp,
@@ -68,7 +81,7 @@ class Pack:
         # ### /* block 5. ToFasta */ ###
         self.console.print('=========>++++++++++++++++++++to Fasta...\n+++++++++++++++++++++++++++')
         ToFasta(
-            prot_df=self.prot_df,
+            prot_df=prot_df,
             sv_fp=fasta_fp
         ).frompdb(
             pdb_path=pdb_fp + '/delend/',
@@ -76,11 +89,104 @@ class Pack:
         # ### /* block 6. isEmpty */ ###
         self.console.print('=========>++++++++++++++++++++is empty...\n+++++++++++++++++++++++++++')
         IsEmpty(
-            self.prot_df,
+            prot_df,
             sv_empty_fp=fasta_fp,
             fasta_fp=fasta_fp,
         ).fasta()
         return 'Finished'
+
+    def _sanitize_complex_pdbs(
+            self,
+            pdb_cplx_fp,
+            pdb_fp,
+    ):
+        """
+        Write ligand-stripped complex PDB copies for Biopython chain splitting.
+
+        PyPropel removes HETATM records later in the pack flow, but Biopython
+        parses the whole complex before that stage. Some PDBTM transformed
+        entries contain malformed ligand HETATM records whose fixed-width
+        columns make Biopython reject the entire structure. Removing HETATM
+        records before splitting preserves protein ATOM records and matches the
+        eventual packed-chain content.
+        """
+        sanitized_fp = os.path.join(pdb_fp, 'complex_no_hetatm') + '/'
+        FileIO().makedir(sanitized_fp)
+        rows = []
+        for prot_name in pd.unique(self.prot_df['prot']):
+            src = os.path.join(pdb_cplx_fp, str(prot_name) + '.pdb')
+            dst = os.path.join(sanitized_fp, str(prot_name) + '.pdb')
+            row = {
+                'prot': prot_name,
+                'source': src,
+                'sanitized': dst,
+                'atom_records': 0,
+                'hetatm_removed': 0,
+                'malformed_records_removed': 0,
+                'status': 'ok',
+            }
+            try:
+                with open(src) as fin, open(dst, 'w') as fout:
+                    for line in fin:
+                        if line.startswith('ATOM  '):
+                            row['atom_records'] += 1
+                            fout.write(line)
+                        elif line.startswith('HETATM'):
+                            row['hetatm_removed'] += 1
+                            if self._has_invalid_pdb_resseq(line):
+                                row['malformed_records_removed'] += 1
+                        else:
+                            fout.write(line)
+            except FileNotFoundError:
+                row['status'] = 'missing_source'
+            rows.append(row)
+        pd.DataFrame(rows).to_csv(
+            os.path.join(pdb_fp, 'complex_sanitize_manifest.txt'),
+            sep='\t',
+            index=False,
+        )
+        return sanitized_fp
+
+    def _filter_existing_split_chains(
+            self,
+            pdb_fp,
+    ):
+        ok_rows = []
+        missing_rows = []
+        for i in self.prot_df.index:
+            prot_name = self.prot_df.loc[i, 'prot']
+            prot_chain = self.prot_df.loc[i, 'chain']
+            file_chain = chainname().chain(prot_chain)
+            chain_fpn = os.path.join(pdb_fp, str(prot_name) + file_chain + '.pdb')
+            row = {
+                'prot': prot_name,
+                'chain': prot_chain,
+                'path': chain_fpn,
+            }
+            if os.path.isfile(chain_fpn) and os.path.getsize(chain_fpn) > 0:
+                ok_rows.append({'prot': prot_name, 'chain': prot_chain})
+            else:
+                missing_rows.append(row)
+        pd.DataFrame(missing_rows).to_csv(
+            os.path.join(pdb_fp, 'missing_split_records.txt'),
+            sep='\t',
+            index=False,
+        )
+        pd.DataFrame(ok_rows).to_csv(
+            os.path.join(pdb_fp, 'successful_split_records.txt'),
+            sep='\t',
+            index=False,
+        )
+        return pd.DataFrame(ok_rows, columns=['prot', 'chain']).reset_index(drop=True)
+
+    def _has_invalid_pdb_resseq(self, line):
+        if not line.startswith(('ATOM  ', 'HETATM')):
+            return False
+        try:
+            int(line[22:26].split()[0])
+        except (IndexError, ValueError):
+            return True
+        return False
 
 
 if __name__ == "__main__":

--- a/tests/test_pack.py
+++ b/tests/test_pack.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import pandas as pd
+
+from pypropel.prot.file.Pack import Pack
+from pypropel.prot.structure.chain.Splitter import Splitter
+
+
+class PackTest(unittest.TestCase):
+    def test_sanitized_complex_pdb_splits_when_malformed_hetatm_exists(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            complex_dir = root / "complex"
+            packed_dir = root / "packed"
+            complex_dir.mkdir()
+            packed_dir.mkdir()
+            (complex_dir / "2acz.pdb").write_text(
+                "\n".join(
+                    [
+                        "HEADER    TEST PDB",
+                        "ATOM      1  N   ALA C   1      11.104  13.207   2.100  1.00 20.00           N",
+                        "ATOM      2  CA  ALA C   1      12.104  13.207   2.100  1.00 20.00           C",
+                        "HETATM    3  CL12 AT5 C 131      21.657 -24.957  15.072  1.00 85.07           C",
+                        "ATOM      4  N   GLY D   1      10.104  12.207   2.100  1.00 20.00           N",
+                        "ATOM      5  CA  GLY D   1      10.704  12.807   2.800  1.00 20.00           C",
+                        "END",
+                    ]
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            prot_df = pd.DataFrame({"prot": ["2acz", "2acz"], "chain": ["C", "D"]})
+            pack = Pack(prot_df=prot_df, verbose=False)
+
+            sanitized_dir = pack._sanitize_complex_pdbs(
+                pdb_cplx_fp=str(complex_dir) + "/",
+                pdb_fp=str(packed_dir) + "/",
+            )
+            Splitter(
+                prot_df=prot_df,
+                pdb_path=sanitized_dir,
+                sv_fp=str(packed_dir) + "/",
+                verbose=False,
+            ).pdb_per_chain()
+            split_df = pack._filter_existing_split_chains(str(packed_dir) + "/")
+
+            self.assertEqual(
+                split_df.to_dict(orient="records"),
+                [{"prot": "2acz", "chain": "C"}, {"prot": "2acz", "chain": "D"}],
+            )
+            self.assertTrue((packed_dir / "2aczC.pdb").exists())
+            self.assertTrue((packed_dir / "2aczD.pdb").exists())
+            manifest = pd.read_csv(packed_dir / "complex_sanitize_manifest.txt", sep="\t")
+            self.assertEqual(int(manifest.loc[0, "hetatm_removed"]), 1)
+            self.assertEqual(int(manifest.loc[0, "malformed_records_removed"]), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- strip HETATM records from temporary complex PDB copies before Biopython chain splitting
- continue packing only chains whose split PDB files were created
- write sanitize/split manifests for skipped-chain QC
- add a regression test for malformed ligand HETATM records that previously broke packing

## Validation
- python3 -m pytest tests/test_pack.py -q
