### PR TITLE
[codex] Optimize PyPropel hot paths

### DIFF
--- a/benchmarks/benchmark_alignment_frequency.py
+++ b/benchmarks/benchmark_alignment_frequency.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import timeit
+import sys
+import importlib.util
+from pathlib import Path
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from pypropel.prot.feature.alignment.frequency.Single import Single
+
+
+def load_test_helpers():
+    path = ROOT / "tests" / "test_alignment_frequency_optimization.py"
+    spec = importlib.util.spec_from_file_location("alignment_frequency_helpers", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+helpers = load_test_helpers()
+legacy_alignment = helpers.legacy_alignment
+legacy_columns = helpers.legacy_columns
+
+
+def make_msa(rows=1500, cols=700):
+    rng = np.random.default_rng(42)
+    alphabet = np.array(list("ACDEFGHIKLMNPQRSTVWY-"))
+    return ["".join(row.tolist()) for row in rng.choice(alphabet, size=(rows, cols))]
+
+
+def bench(name, func, number=3):
+    elapsed = timeit.timeit(func, number=number) / number
+    print(f"{name}: {elapsed:.6f}s")
+
+
+if __name__ == "__main__":
+    msa = make_msa()
+    freq, omit = Single(msa).columns()
+    legacy_freq, legacy_omit = legacy_columns(msa)
+    for aa in legacy_freq:
+        np.testing.assert_allclose(freq[aa], legacy_freq[aa])
+    np.testing.assert_allclose(omit, legacy_omit)
+    assert Single(msa).alignment() == legacy_alignment(msa)
+
+    bench("legacy columns", lambda: legacy_columns(msa), number=1)
+    bench("optimized columns", lambda: Single(msa).columns(), number=5)
+    bench("legacy alignment", lambda: legacy_alignment(msa), number=1)
+    bench("optimized alignment", lambda: Single(msa).alignment(), number=5)

--- a/benchmarks/benchmark_alignment_representation.py
+++ b/benchmarks/benchmark_alignment_representation.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import timeit
+import sys
+import importlib.util
+from pathlib import Path
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from pypropel.prot.feature.alignment.representation.Binary import Binary
+from pypropel.prot.feature.alignment.representation.Frequency import Frequency
+
+
+def load_test_helpers():
+    path = ROOT / "tests" / "test_alignment_representation_optimization.py"
+    spec = importlib.util.spec_from_file_location("alignment_representation_helpers", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+helpers = load_test_helpers()
+legacy_matrix = helpers.legacy_matrix
+legacy_onehot = helpers.legacy_onehot
+
+
+def make_msa(rows=180, cols=80):
+    rng = np.random.default_rng(7)
+    alphabet = np.array(list("ACDEFGHIKLMNPQRSTVWY-"))
+    return ["".join(row.tolist()) for row in rng.choice(alphabet, size=(rows, cols))]
+
+
+def bench(name, func, number=3):
+    elapsed = timeit.timeit(func, number=number) / number
+    print(f"{name}: {elapsed:.6f}s")
+
+
+if __name__ == "__main__":
+    msa = make_msa()
+    np.testing.assert_array_equal(Binary(msa).onehot(), legacy_onehot(msa))
+    np.testing.assert_allclose(Frequency(msa).matrix(), legacy_matrix(msa))
+
+    bench("legacy onehot", lambda: legacy_onehot(msa), number=1)
+    bench("optimized onehot", lambda: Binary(msa).onehot(), number=5)
+    bench("legacy frequency matrix", lambda: legacy_matrix(msa), number=1)
+    bench("optimized frequency matrix", lambda: Frequency(msa).matrix(), number=3)

--- a/benchmarks/benchmark_distance.py
+++ b/benchmarks/benchmark_distance.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import timeit
+import sys
+import importlib.util
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+
+def load_test_helpers():
+    path = ROOT / "tests" / "test_distance_optimization.py"
+    spec = importlib.util.spec_from_file_location("distance_helpers", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+helpers = load_test_helpers()
+ConcreteDistance = helpers.ConcreteDistance
+chain = helpers.chain
+legacy_one2one_all = helpers.legacy_one2one_all
+residue = helpers.residue
+
+
+def make_chain(chain_id, offset, residues=30, atoms=5):
+    built = []
+    for res_id in range(1, residues + 1):
+        coords = [
+            (f"C{atom_id}", (float(res_id + offset), float(atom_id), float(atom_id % 3)))
+            for atom_id in range(atoms)
+        ]
+        built.append(residue("ALA", res_id, coords))
+    return chain(chain_id, built)
+
+
+def bench(name, func, number=3):
+    elapsed = timeit.timeit(func, number=number) / number
+    print(f"{name}: {elapsed:.6f}s")
+
+
+if __name__ == "__main__":
+    chain1 = make_chain("A", 0)
+    chain2 = make_chain("B", 5)
+    dist = ConcreteDistance()
+    assert dist.one2one_all(chain1, chain2) == legacy_one2one_all(chain1, chain2)
+
+    bench("legacy one2one_all", lambda: legacy_one2one_all(chain1, chain2), number=1)
+    bench("optimized one2one_all", lambda: dist.one2one_all(chain1, chain2), number=3)

--- a/benchmarks/benchmark_feature_assembly.py
+++ b/benchmarks/benchmark_feature_assembly.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import timeit
+
+import numpy as np
+import pandas as pd
+
+from pypropel.prot.feature.PSSM import PSSM
+from pypropel.prot.feature.rsa.Assemble import Assemble as RSAAssemble
+from pypropel.prot.feature.ss.Assemble import Assemble as SSAssemble
+
+
+def make_pair_windows(rows=1000, width=5):
+    windows = []
+    for i in range(rows):
+        left = [None if j == 0 else ((i + j) % rows) + 1 for j in range(width)]
+        right = [((i + j + width) % rows) + 1 for j in range(width)]
+        windows.append((left, right))
+    return windows
+
+
+def legacy_psipred(df_psipred_ss2, list_2d, window_aa_ids):
+    psipred = df_psipred_ss2.values.tolist()
+    window_aa_ids_ = [i[0] + i[1] for i in window_aa_ids]
+    list_2d_ = list_2d
+    for i, aa_win_ids in enumerate(window_aa_ids_):
+        for j in aa_win_ids:
+            if j is None:
+                list_2d_[i] = list_2d_[i] + np.zeros(3).tolist()
+            else:
+                list_2d_[i] = list_2d_[i] + psipred[j-1][3:]
+    return list_2d_
+
+
+def legacy_solvpred(df_solvpred, list_2d, window_aa_ids):
+    solvpred = df_solvpred.values.tolist()
+    window_aa_ids_ = [i[0] + i[1] for i in window_aa_ids]
+    list_2d_ = list_2d
+    for i, aa_win_ids in enumerate(window_aa_ids_):
+        for j in aa_win_ids:
+            if j is None:
+                list_2d_[i].append(0)
+            else:
+                list_2d_[i].append(solvpred[j-1][2])
+    return list_2d_
+
+
+def legacy_blast(pssm, list_2d, window_aa_ids):
+    list_2d_ = list_2d
+    for i, aa_win_ids in enumerate(window_aa_ids):
+        for j in aa_win_ids:
+            for k in j:
+                if k is None:
+                    list_2d_[i] = list_2d_[i] + [0 for i in range(20)]
+                else:
+                    list_2d_[i] = list_2d_[i] + pssm[k]
+    return list_2d_
+
+
+def bench(name, func, number=3):
+    elapsed = timeit.timeit(func, number=number) / number
+    print(f"{name}: {elapsed:.6f}s")
+
+
+if __name__ == "__main__":
+    windows = make_pair_windows()
+    base = [[i] for i in range(len(windows))]
+    psipred = pd.DataFrame([[i, "A", "H", 0.1, 0.2, 0.7] for i in range(len(windows))])
+    solvpred = pd.DataFrame([[i, "A", 0.5] for i in range(len(windows))])
+    pssm = {i + 1: [float(i % 20)] * 20 for i in range(len(windows))}
+    nested_windows = [[left, right] for left, right in windows]
+
+    assert SSAssemble().psipred(psipred, [row[:] for row in base], windows) == legacy_psipred(psipred, [row[:] for row in base], windows)
+    assert RSAAssemble().solvpred(solvpred, [row[:] for row in base], windows, mode="pair") == legacy_solvpred(solvpred, [row[:] for row in base], windows)
+    assert PSSM().blast_(pssm, [row[:] for row in base], nested_windows) == legacy_blast(pssm, [row[:] for row in base], nested_windows)
+
+    bench("legacy psipred", lambda: legacy_psipred(psipred, [row[:] for row in base], windows), number=2)
+    bench("optimized psipred", lambda: SSAssemble().psipred(psipred, [row[:] for row in base], windows), number=5)
+    bench("legacy solvpred", lambda: legacy_solvpred(solvpred, [row[:] for row in base], windows), number=2)
+    bench("optimized solvpred", lambda: RSAAssemble().solvpred(solvpred, [row[:] for row in base], windows, mode="pair"), number=5)
+    bench("legacy blast", lambda: legacy_blast(pssm, [row[:] for row in base], nested_windows), number=2)
+    bench("optimized blast", lambda: PSSM().blast_(pssm, [row[:] for row in base], nested_windows), number=5)

--- a/benchmarks/benchmark_import_startup.py
+++ b/benchmarks/benchmark_import_startup.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+
+
+def run_python(statement):
+    start = time.perf_counter()
+    result = subprocess.run(
+        [sys.executable, "-c", statement],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        timeout=20,
+    )
+    result.check_returncode()
+    return time.perf_counter() - start
+
+
+def bench(name, statement):
+    elapsed = run_python(statement)
+    print(f"{name}: {elapsed:.6f}s")
+
+
+if __name__ == "__main__":
+    bench("import pypropel", "import pypropel")
+    bench("import pypropel then msa", "import pypropel; pypropel.msa")

--- a/pypropel/__init__.py
+++ b/pypropel/__init__.py
@@ -1,20 +1,27 @@
-import sys
+from importlib import import_module
 
-from . import (
-    dist,
-    dataset,
-    msa,
-    eval,
-    # fcsdf,
-    fpmsa,
-    fpseq,
-    fpstr,
-    fpsite,
-    external,
-    convert,
-    io,
-    plot,
-    seq,
-    str,
-    uniprot,
-)
+__all__ = [
+    'dist',
+    'dataset',
+    'msa',
+    'eval',
+    'fpmsa',
+    'fpseq',
+    'fpstr',
+    'fpsite',
+    'external',
+    'convert',
+    'io',
+    'plot',
+    'seq',
+    'str',
+    'uniprot',
+]
+
+
+def __getattr__(name):
+    if name not in __all__:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module = import_module(f"{__name__}.{name}")
+    globals()[name] = module
+    return module

--- a/pypropel/prot/feature/PSSM.py
+++ b/pypropel/prot/feature/PSSM.py
@@ -87,15 +87,18 @@ class PSSM:
             window_aa_ids,
     ):
         list_2d_ = list_2d
+        zero = [0 for _ in range(20)]
         for i, aa_win_ids in enumerate(window_aa_ids):
+            row_features = []
             for j in aa_win_ids:
                 # print(j)
                 for k in j:
                     # print(k)
                     if k is None:
-                        list_2d_[i] = list_2d_[i] + [0 for i in range(20)]
+                        row_features.extend(zero)
                     else:
-                        list_2d_[i] = list_2d_[i] + pssm[k]
+                        row_features.extend(pssm[k])
+            list_2d_[i].extend(row_features)
         return list_2d_
 
     def hhm_(
@@ -105,15 +108,18 @@ class PSSM:
             window_aa_ids,
     ):
         list_2d_ = list_2d
+        zero = [0 for _ in range(30)]
         for i, aa_win_ids in enumerate(window_aa_ids):
+            row_features = []
             for j in aa_win_ids:
                 # print(j)
                 for k in j:
                     # print(k)
                     if k is None:
-                        list_2d_[i] = list_2d_[i] + [0 for i in range(30)]
+                        row_features.extend(zero)
                     else:
-                        list_2d_[i] = list_2d_[i] + hhm[k].tolist()
+                        row_features.extend(hhm[k].tolist())
+            list_2d_[i].extend(row_features)
         return list_2d_
 
 

--- a/pypropel/prot/feature/alignment/frequency/Single.py
+++ b/pypropel/prot/feature/alignment/frequency/Single.py
@@ -21,6 +21,16 @@ class Single:
         self.msa_row = len(self.msa)
         self.msa_col = len(self.msa[0])
 
+    def _encoded(self, ):
+        arr = np.frombuffer(''.join(self.msa).encode('ascii'), dtype=np.uint8)
+        return arr.reshape(self.msa_row, self.msa_col)
+
+    def _alphabet_codes(self, ):
+        lut = np.full(256, -1, dtype=np.int16)
+        for i, aa in enumerate(self.aa_alphabet):
+            lut[ord(aa)] = i
+        return lut[self._encoded()]
+
     def columns(self, ):
         """
         Frequency of 20 amino acids and 1 gap in each column of msa.
@@ -41,81 +51,20 @@ class Single:
             row: 75; col: 21
 
         """
-        A = [0] * self.msa_col
-        C = [0] * self.msa_col
-        D = [0] * self.msa_col
-        E = [0] * self.msa_col
-        F = [0] * self.msa_col
-        G = [0] * self.msa_col
-        H = [0] * self.msa_col
-        I = [0] * self.msa_col
-        K = [0] * self.msa_col
-        L = [0] * self.msa_col
-        M = [0] * self.msa_col
-        N = [0] * self.msa_col
-        P = [0] * self.msa_col
-        Q = [0] * self.msa_col
-        R = [0] * self.msa_col
-        S = [0] * self.msa_col
-        T = [0] * self.msa_col
-        V = [0] * self.msa_col
-        W = [0] * self.msa_col
-        Y = [0] * self.msa_col
-        omit = [0] * self.msa_col
-        # print(self.msa)
-        for homolog in self.msa:
-            # print(homolog)
-            for alignment_pos, base in enumerate(homolog):
-                if base == 'A':
-                    A[alignment_pos] += 1
-                elif base == 'C':
-                    C[alignment_pos] += 1
-                elif base == 'D':
-                    D[alignment_pos] += 1
-                elif base == 'E':
-                    E[alignment_pos] += 1
-                elif base == 'F':
-                    F[alignment_pos] += 1
-                elif base == 'G':
-                    G[alignment_pos] += 1
-                elif base == 'H':
-                    H[alignment_pos] += 1
-                elif base == 'I':
-                    I[alignment_pos] += 1
-                elif base == 'K':
-                    K[alignment_pos] += 1
-                elif base == 'L':
-                    L[alignment_pos] += 1
-                elif base == 'M':
-                    M[alignment_pos] += 1
-                elif base == 'N':
-                    N[alignment_pos] += 1
-                elif base == 'P':
-                    P[alignment_pos] += 1
-                elif base == 'Q':
-                    Q[alignment_pos] += 1
-                elif base == 'R':
-                    R[alignment_pos] += 1
-                elif base == 'S':
-                    S[alignment_pos] += 1
-                elif base == 'T':
-                    T[alignment_pos] += 1
-                elif base == 'V':
-                    V[alignment_pos] += 1
-                elif base == 'W':
-                    W[alignment_pos] += 1
-                elif base == 'Y':
-                    Y[alignment_pos] += 1
-                elif base == '-':
-                    omit[alignment_pos] += 1
-        count_array = np.array([A, C, D, E, F, G, H, I, K, L, M, N, P, Q, R, S, T, V, W, Y, omit])
-        # count_array = [A, C, D, E, F, G, H, I, K, L, M, N, P, Q, R, S, T, V, W, Y, omit]
-        # freq_array = count_array
+        codes = self._alphabet_codes()
+        valid = codes >= 0
+        col_offsets = np.arange(self.msa_col, dtype=np.int64) * len(self.aa_alphabet)
+        flat_ids = (codes + col_offsets).ravel()
+        counts = np.bincount(
+            flat_ids[valid.ravel()],
+            minlength=self.msa_col * len(self.aa_alphabet),
+        )
+        count_array = counts.reshape(self.msa_col, len(self.aa_alphabet)).T
         freq_array = count_array / self.msa_row
         freq = {}
         for i, aa in enumerate(self.aa_alphabet):
             freq[aa] = freq_array[i]
-        return freq, np.array(omit) / self.msa_row
+        return freq, freq['-']
 
     def columnsByPandas(self, ):
         msa_sp = []
@@ -154,74 +103,12 @@ class Single:
              row: 1; col: 21
         """
         total_num_MSA = self.msa_row * self.msa_col
-        A = 0
-        C = 0
-        D = 0
-        E = 0
-        F = 0
-        G = 0
-        H = 0
-        I = 0
-        K = 0
-        L = 0
-        M = 0
-        N = 0
-        P = 0
-        Q = 0
-        R = 0
-        S = 0
-        T = 0
-        V = 0
-        W = 0
-        Y = 0
-        omit = 0
-        for i in range(self.msa_row):
-            for j in range(self.msa_col):
-                if self.msa[i][j] == 'A':
-                    A += 1
-                elif self.msa[i][j] == 'C':
-                    C += 1
-                elif self.msa[i][j] == 'D':
-                    D += 1
-                elif self.msa[i][j] == 'E':
-                    E += 1
-                elif self.msa[i][j] == 'F':
-                    F += 1
-                elif self.msa[i][j] == 'G':
-                    G += 1
-                elif self.msa[i][j] == 'H':
-                    H += 1
-                elif self.msa[i][j] == 'I':
-                    I += 1
-                elif self.msa[i][j] == 'K':
-                    K += 1
-                elif self.msa[i][j] == 'L':
-                    L += 1
-                elif self.msa[i][j] == 'M':
-                    M += 1
-                elif self.msa[i][j] == 'N':
-                    N += 1
-                elif self.msa[i][j] == 'P':
-                    P += 1
-                elif self.msa[i][j] == 'Q':
-                    Q += 1
-                elif self.msa[i][j] == 'R':
-                    R += 1
-                elif self.msa[i][j] == 'S':
-                    S += 1
-                elif self.msa[i][j] == 'T':
-                    T += 1
-                elif self.msa[i][j] == 'V':
-                    V += 1
-                elif self.msa[i][j] == 'W':
-                    W += 1
-                elif self.msa[i][j] == 'Y':
-                    Y += 1
-                elif self.msa[i][j] == '-':
-                    omit += 1
-        freq_array = np.array([
-            A, C, D, E, F, G, H, I, K, L, M, N, P, Q, R, S, T, V, W, Y, omit
-        ]) / total_num_MSA
+        codes = self._alphabet_codes()
+        counts = np.bincount(
+            codes[codes >= 0],
+            minlength=len(self.aa_alphabet),
+        )
+        freq_array = counts / total_num_MSA
         freq = {}
         for i, aa in enumerate(self.aa_alphabet):
             freq[aa] = freq_array[i]

--- a/pypropel/prot/feature/alignment/representation/Binary.py
+++ b/pypropel/prot/feature/alignment/representation/Binary.py
@@ -16,50 +16,14 @@ class Binary:
         self.msa_col = len(self.msa[0])
 
     def onehot(self):
-        binary_matrix = [[0 for _ in range(self.msa_col * 21)] for _ in range(self.msa_row)]
-        for i in range(self.msa_row):
-            for j in range(self.msa_col):
-                if 'A' == self.msa[i][j]:
-                    binary_matrix[i][j * 21 + 0] = 1
-                elif 'C' == self.msa[i][j]:
-                    binary_matrix[i][j * 21 + 1] = 1
-                elif 'D' == self.msa[i][j]:
-                    binary_matrix[i][j * 21 + 2] = 1
-                elif 'E' == self.msa[i][j]:
-                    binary_matrix[i][j * 21 + 3] = 1
-                elif 'F' == self.msa[i][j]:
-                    binary_matrix[i][j * 21 + 4] = 1
-                elif 'G' == self.msa[i][j]:
-                    binary_matrix[i][j * 21 + 5] = 1
-                elif 'H' == self.msa[i][j]:
-                    binary_matrix[i][j * 21 + 6] = 1
-                elif 'I' == self.msa[i][j]:
-                    binary_matrix[i][j * 21 + 7] = 1
-                elif 'K' == self.msa[i][j]:
-                    binary_matrix[i][j * 21 + 8] = 1
-                elif 'L' == self.msa[i][j]:
-                    binary_matrix[i][j * 21 + 9] = 1
-                elif 'M' == self.msa[i][j]:
-                    binary_matrix[i][j * 21 + 10] = 1
-                elif 'N' == self.msa[i][j]:
-                    binary_matrix[i][j * 21 + 11] = 1
-                elif 'P' == self.msa[i][j]:
-                    binary_matrix[i][j * 21 + 12] = 1
-                elif 'Q' == self.msa[i][j]:
-                    binary_matrix[i][j * 21 + 13] = 1
-                elif 'R' == self.msa[i][j]:
-                    binary_matrix[i][j * 21 + 14] = 1
-                elif 'S' == self.msa[i][j]:
-                    binary_matrix[i][j * 21 + 15] = 1
-                elif 'T' == self.msa[i][j]:
-                    binary_matrix[i][j * 21 + 16] = 1
-                elif 'V' == self.msa[i][j]:
-                    binary_matrix[i][j * 21 + 17] = 1
-                elif 'W' == self.msa[i][j]:
-                    binary_matrix[i][j * 21 + 18] = 1
-                elif 'Y' == self.msa[i][j]:
-                    binary_matrix[i][j * 21 + 19] = 1
-                elif '-' == self.msa[i][j]:
-                    binary_matrix[i][j * 21 + 20] = 1
-        binary_matrix = np.array(binary_matrix)
-        return binary_matrix
+        encoded = np.frombuffer(''.join(self.msa).encode('ascii'), dtype=np.uint8)
+        encoded = encoded.reshape(self.msa_row, self.msa_col)
+        lut = np.full(256, -1, dtype=np.int16)
+        for i, aa in enumerate(b'ACDEFGHIKLMNPQRSTVWY-'):
+            lut[aa] = i
+        codes = lut[encoded]
+        binary_matrix = np.zeros((self.msa_row, self.msa_col, 21), dtype=int)
+        valid = codes >= 0
+        row_ids, col_ids = np.nonzero(valid)
+        binary_matrix[row_ids, col_ids, codes[valid]] = 1
+        return binary_matrix.reshape(self.msa_row, self.msa_col * 21)

--- a/pypropel/prot/feature/alignment/representation/Frequency.py
+++ b/pypropel/prot/feature/alignment/representation/Frequency.py
@@ -6,7 +6,6 @@ __email__ = "jianfeng.sunmt@gmail.com"
 __maintainer__ = "Jianfeng Sun"
 
 import numpy as np
-from collections import Counter
 from pypropel.prot.feature.alignment.symbol.Single import Single as sglalignsymbol
 
 
@@ -18,29 +17,29 @@ class Frequency:
         self.passingle = sglalignsymbol(self.msa)
 
     def calc_sgl_col(self, x):
-        bases = self.passingle.extract(x)
-        # print(bases[1])
-        num_total = len(bases)
-        freq_dictionary = Counter(bases)
-        freq_all_bases = freq_dictionary.most_common()
-        # print(freq_all_bases)
-        template_num = len(freq_all_bases)
-        # print(template_num)
-        freq_single = [0 for _ in range(num_total)]
-        # print(num_total)
-        for i in range(template_num):
-            for j in range(num_total):
-                if np.array_equal(freq_all_bases[i][0], bases[j]):
-                    freq_single[j] = round(freq_all_bases[i][1] / num_total, 4)
-                    if bases[j] == '-':
-                        freq_single[j] = 0
-        return freq_single
+        bases = np.array(self.passingle.extract(x))
+        num_total = bases.shape[0]
+        values, inverse, counts = np.unique(
+            bases,
+            return_inverse=True,
+            return_counts=True,
+        )
+        freq_single = np.round(counts[inverse] / num_total, 4)
+        freq_single[values[inverse] == '-'] = 0
+        return freq_single.tolist()
 
     def matrix(self ):
-        base_freq_matrix_T = []
+        msa_matrix = np.array([list(row) for row in self.msa])
+        base_freq_matrix = np.zeros(msa_matrix.shape, dtype=float)
         for i in range(self.msa_col):
-            base_freq_matrix_T.append(self.calc_sgl_col(i))
-        base_freq_matrix = np.transpose(np.array(base_freq_matrix_T))
+            values, inverse, counts = np.unique(
+                msa_matrix[:, i],
+                return_inverse=True,
+                return_counts=True,
+            )
+            col_freq = np.round(counts[inverse] / msa_matrix.shape[0], 4)
+            col_freq[values[inverse] == '-'] = 0
+            base_freq_matrix[:, i] = col_freq
         return base_freq_matrix
 
 

--- a/pypropel/prot/feature/rsa/Assemble.py
+++ b/pypropel/prot/feature/rsa/Assemble.py
@@ -32,18 +32,21 @@ class Assemble:
         print(df_accpro)
         window_aa_ids_ = window_aa_ids if mode == 'single' else [i[0] + i[1] for i in window_aa_ids]
         list_2d_ = list_2d
+        zero = np.zeros(2).tolist()
         for i, aa_win_ids in enumerate(window_aa_ids_):
             # print(i)
             # print(aa_win_ids)
+            row_features = []
             for j in aa_win_ids:
                 # print(aa_win_ids)
                 if j is None:
-                    list_2d_[i] = list_2d_[i] + np.zeros(2).tolist()
+                    row_features.extend(zero)
                 else:
                     if accpro[j - 1][0] == 'e':
-                        list_2d_[i] = list_2d_[i] + [0, 1]
+                        row_features.extend([0, 1])
                     else:
-                        list_2d_[i] = list_2d_[i] + [1, 0]
+                        row_features.extend([1, 0])
+            list_2d_[i].extend(row_features)
         end_time = time.time()
         self.console.print('=========>ACCpro solvent: {time}s.'.format(time=end_time - start_time))
         return list_2d_
@@ -60,53 +63,42 @@ class Assemble:
         # print(accpro20)
         window_aa_ids_ = window_aa_ids if mode == 'single' else [i[0] + i[1] for i in window_aa_ids]
         list_2d_ = list_2d
+        zero = np.zeros(20).tolist()
+        value_to_index = {
+            0.0: 19,
+            0.05: 18,
+            0.1: 17,
+            0.15: 16,
+            0.2: 15,
+            0.25: 14,
+            0.3: 13,
+            0.35: 12,
+            0.4: 11,
+            0.45: 10,
+            0.5: 9,
+            0.55: 8,
+            0.6: 7,
+            0.65: 6,
+            0.7: 5,
+            0.75: 4,
+            0.205: 2,
+            0.9: 1,
+        }
+        onehot = {
+            value: [1 if idx == active_idx else 0 for idx in range(20)]
+            for value, active_idx in value_to_index.items()
+        }
+        default = [1 if idx == 0 else 0 for idx in range(20)]
         for i, aa_win_ids in enumerate(window_aa_ids_):
             # print(i)
+            row_features = []
             for j in aa_win_ids:
                 # print(aa_win_ids)
                 if j is None:
-                    list_2d_[i] = list_2d_[i] + np.zeros(20).tolist()
+                    row_features.extend(zero)
                 else:
-                    if accpro20[j - 1][0] == 0.0:
-                        list_2d_[i] = list_2d_[i] + [1 if i == 19 else 0 for i in range(20)]
-                    elif accpro20[j - 1][0] == 0.05:
-                        list_2d_[i] = list_2d_[i] + [1 if i == 18 else 0 for i in range(20)]
-                    elif accpro20[j - 1][0] == 0.1:
-                        list_2d_[i] = list_2d_[i] + [1 if i == 17 else 0 for i in range(20)]
-                    elif accpro20[j - 1][0] == 0.15:
-                        list_2d_[i] = list_2d_[i] + [1 if i == 16 else 0 for i in range(20)]
-                    elif accpro20[j - 1][0] == 0.2:
-                        list_2d_[i] = list_2d_[i] + [1 if i == 15 else 0 for i in range(20)]
-                    elif accpro20[j - 1][0] == 0.25:
-                        list_2d_[i] = list_2d_[i] + [1 if i == 14 else 0 for i in range(20)]
-                    elif accpro20[j - 1][0] == 0.3:
-                        list_2d_[i] = list_2d_[i] + [1 if i == 13 else 0 for i in range(20)]
-                    elif accpro20[j - 1][0] == 0.35:
-                        list_2d_[i] = list_2d_[i] + [1 if i == 12 else 0 for i in range(20)]
-                    elif accpro20[j - 1][0] == 0.4:
-                        list_2d_[i] = list_2d_[i] + [1 if i == 11 else 0 for i in range(20)]
-                    elif accpro20[j - 1][0] == 0.45:
-                        list_2d_[i] = list_2d_[i] + [1 if i == 10 else 0 for i in range(20)]
-                    elif accpro20[j - 1][0] == 0.5:
-                        list_2d_[i] = list_2d_[i] + [1 if i == 9 else 0 for i in range(20)]
-                    elif accpro20[j - 1][0] == 0.55:
-                        list_2d_[i] = list_2d_[i] + [1 if i == 8 else 0 for i in range(20)]
-                    elif accpro20[j - 1][0] == 0.6:
-                        list_2d_[i] = list_2d_[i] + [1 if i == 7 else 0 for i in range(20)]
-                    elif accpro20[j - 1][0] == 0.65:
-                        list_2d_[i] = list_2d_[i] + [1 if i == 6 else 0 for i in range(20)]
-                    elif accpro20[j - 1][0] == 0.7:
-                        list_2d_[i] = list_2d_[i] + [1 if i == 5 else 0 for i in range(20)]
-                    elif accpro20[j - 1][0] == 0.75:
-                        list_2d_[i] = list_2d_[i] + [1 if i == 4 else 0 for i in range(20)]
-                    elif accpro20[j - 1][0] == 0.20:
-                        list_2d_[i] = list_2d_[i] + [1 if i == 3 else 0 for i in range(20)]
-                    elif accpro20[j - 1][0] == 0.205:
-                        list_2d_[i] = list_2d_[i] + [1 if i == 2 else 0 for i in range(20)]
-                    elif accpro20[j - 1][0] == 0.9:
-                        list_2d_[i] = list_2d_[i] + [1 if i == 1 else 0 for i in range(20)]
-                    else:
-                        list_2d_[i] = list_2d_[i] + [1 if i == 0 else 0 for i in range(20)]
+                    row_features.extend(onehot.get(accpro20[j - 1][0], default))
+            list_2d_[i].extend(row_features)
         end_time = time.time()
         self.console.print('=========>ACCpro20 solvent: {time}s.'.format(time=end_time - start_time))
         return list_2d_
@@ -125,12 +117,14 @@ class Assemble:
         list_2d_ = list_2d
         for i, aa_win_ids in enumerate(window_aa_ids_):
             # print(i)
+            row_features = []
             for j in aa_win_ids:
                 # print(aa_win_ids)
                 if j is None:
-                    list_2d_[i].append(0)
+                    row_features.append(0)
                 else:
-                    list_2d_[i].append(solvpred[j-1][2])
+                    row_features.append(solvpred[j-1][2])
+            list_2d_[i].extend(row_features)
         end_time = time.time()
         print('=========>solvpred solvent: {time}s.'.format(time=end_time - start_time))
         return list_2d_

--- a/pypropel/prot/feature/ss/Assemble.py
+++ b/pypropel/prot/feature/ss/Assemble.py
@@ -33,15 +33,19 @@ class Assemble:
         # print(spider3)
         window_aa_ids_ = [i[0] + i[1] for i in window_aa_ids]
         list_2d_ = list_2d
+        standardize = Standardize()
+        zero = np.zeros(13).tolist()
         for i, aa_win_ids in enumerate(window_aa_ids_):
             # print(i)
+            row_features = []
             for j in aa_win_ids:
                 # print(aa_win_ids)
                 if j is None:
-                    list_2d_[i] = list_2d_[i] + np.zeros(13).tolist()
+                    row_features.extend(zero)
                 else:
-                    trans = Standardize().minmax1(spider3[j-1][mark:]) if std else spider3[j-1][mark:]
-                    list_2d_[i] = list_2d_[i] + trans
+                    trans = standardize.minmax1(spider3[j-1][mark:]) if std else spider3[j-1][mark:]
+                    row_features.extend(trans)
+            list_2d_[i].extend(row_features)
         end_time = time.time()
         print('------> spider3 ss: {time}s.'.format(time=end_time - start_time))
         return list_2d_
@@ -57,20 +61,23 @@ class Assemble:
         print(sspro)
         window_aa_ids_ = [i[0] + i[1] for i in window_aa_ids]
         list_2d_ = list_2d
+        zero = np.zeros(3).tolist()
         for i, aa_win_ids in enumerate(window_aa_ids_):
+            row_features = []
             for j in aa_win_ids:
                 # print(aa_win_ids)
                 if j is None:
-                    list_2d_[i] = list_2d_[i] + np.zeros(3).tolist()
+                    row_features.extend(zero)
                 else:
 
                     if sspro[j - 1][0] == 'H':
-                        list_2d_[i] = list_2d_[i] + [0, 0, 1]
+                        row_features.extend([0, 0, 1])
                     elif sspro[j - 1][0] == 'E':
-                        list_2d_[i] = list_2d_[i] + [0, 1, 0]
+                        row_features.extend([0, 1, 0])
                     else:
                         print(j - 1)
-                        list_2d_[i] = list_2d_[i] + [1, 0, 0]
+                        row_features.extend([1, 0, 0])
+            list_2d_[i].extend(row_features)
         end_time = time.time()
         print('------> sspro ss: {time}s.'.format(time=end_time - start_time))
         return list_2d_
@@ -86,29 +93,27 @@ class Assemble:
         # print(sspro8)
         window_aa_ids_ = [i[0] + i[1] for i in window_aa_ids]
         list_2d_ = list_2d
+        zero = np.zeros(8).tolist()
+        sspro8_map = {
+            'H': [1 if idx == 7 else 0 for idx in range(8)],
+            'G': [1 if idx == 6 else 0 for idx in range(8)],
+            'I': [1 if idx == 5 else 0 for idx in range(8)],
+            'E': [1 if idx == 4 else 0 for idx in range(8)],
+            'B': [1 if idx == 3 else 0 for idx in range(8)],
+            'T': [1 if idx == 2 else 0 for idx in range(8)],
+            'S': [1 if idx == 1 else 0 for idx in range(8)],
+        }
+        default = [1 if idx == 0 else 0 for idx in range(8)]
         for i, aa_win_ids in enumerate(window_aa_ids_):
             # print(i)
+            row_features = []
             for j in aa_win_ids:
                 # print(aa_win_ids)
                 if j is None:
-                    list_2d_[i] = list_2d_[i] + np.zeros(8).tolist()
+                    row_features.extend(zero)
                 else:
-                    if sspro8[j - 1][0] == 'H':
-                        list_2d_[i] = list_2d_[i] + [1 if i == 7 else 0 for i in range(8)]
-                    elif sspro8[j - 1][0] == 'G':
-                        list_2d_[i] = list_2d_[i] + [1 if i == 6 else 0 for i in range(8)]
-                    elif sspro8[j - 1][0] == 'I':
-                        list_2d_[i] = list_2d_[i] + [1 if i == 5 else 0 for i in range(8)]
-                    elif sspro8[j - 1][0] == 'E':
-                        list_2d_[i] = list_2d_[i] + [1 if i == 4 else 0 for i in range(8)]
-                    elif sspro8[j - 1][0] == 'B':
-                        list_2d_[i] = list_2d_[i] + [1 if i == 3 else 0 for i in range(8)]
-                    elif sspro8[j - 1][0] == 'T':
-                        list_2d_[i] = list_2d_[i] + [1 if i == 2 else 0 for i in range(8)]
-                    elif sspro8[j - 1][0] == 'S':
-                        list_2d_[i] = list_2d_[i] + [1 if i == 1 else 0 for i in range(8)]
-                    else:
-                        list_2d_[i] = list_2d_[i] + [1 if i == 0 else 0 for i in range(8)]
+                    row_features.extend(sspro8_map.get(sspro8[j - 1][0], default))
+            list_2d_[i].extend(row_features)
         end_time = time.time()
         print('------> sspro8 ss: {time}s.'.format(time=end_time - start_time))
         return list_2d_
@@ -124,14 +129,17 @@ class Assemble:
         # print(psipred)
         window_aa_ids_ = [i[0] + i[1] for i in window_aa_ids]
         list_2d_ = list_2d
+        zero = np.zeros(3).tolist()
         for i, aa_win_ids in enumerate(window_aa_ids_):
             # print(i)
+            row_features = []
             for j in aa_win_ids:
                 # print(aa_win_ids)
                 if j is None:
-                    list_2d_[i] = list_2d_[i] + np.zeros(3).tolist()
+                    row_features.extend(zero)
                 else:
-                    list_2d_[i] = list_2d_[i] + psipred[j-1][3:]
+                    row_features.extend(psipred[j-1][3:])
+            list_2d_[i].extend(row_features)
         end_time = time.time()
         print('------> psipred ss: {time}s.'.format(time=end_time - start_time))
         return list_2d_

--- a/pypropel/prot/structure/distance/Distance.py
+++ b/pypropel/prot/structure/distance/Distance.py
@@ -9,6 +9,7 @@ import os
 import sys
 sys.path.append(os.path.dirname(os.getcwd()) + '/')
 from abc import ABCMeta, abstractmethod
+import numpy as np
 # from Bio.PDB.Polypeptide import three_to_one
 from pypropel.util.Console import Console
 console = Console()
@@ -43,6 +44,27 @@ class distance(metaclass=ABCMeta):
     def calculate(self):
         pass
 
+    def _standard_residue_records(self, chain):
+        records = []
+        count_hetatm = 0
+        for index, residue in enumerate(chain):
+            if residue.get_id()[0] != ' ':
+                count_hetatm += 1
+                continue
+            records.append((index, index + 1 - count_hetatm, residue))
+        return records
+
+    def _heavy_atom_coords(self, residue):
+        return np.asarray([
+            atom.get_coord()
+            for atom in residue
+            if atom.get_name() != 'H'
+        ], dtype=float)
+
+    def _min_atom_distance(self, coords1, coords2):
+        diff = coords1[:, np.newaxis, :] - coords2[np.newaxis, :, :]
+        return float(np.sqrt(np.sum(diff * diff, axis=2)).min())
+
     def one2one_minimal(
             self,
             chain1,
@@ -69,41 +91,24 @@ class distance(metaclass=ABCMeta):
         """
         console.verbose = verbose
         dist_matrix = []
-        count_hetamt_1 = 0
-        count_hetamt_2 = 0
-        for index_1, residue_1 in enumerate(chain1):
+        chain2_records = [
+            (index_2, fasta_id_2, residue_2, self._heavy_atom_coords(residue_2))
+            for index_2, fasta_id_2, residue_2 in self._standard_residue_records(chain2)
+        ]
+        for index_1, fasta_id_1, residue_1 in self._standard_residue_records(chain1):
             console.print("==================>residue 1 ID: {}".format(index_1))
-            if residue_1.get_id()[0] != ' ':
-                count_hetamt_1 = count_hetamt_1 + 1
-                continue
-            else:
-                residue_dist = []
-                for index_2, residue_2 in enumerate(chain2):
-                    # console.print("=====================>residue 2 ID: {}".format(index_1))
-                    if residue_2.get_id()[0] != ' ':
-                        count_hetamt_2 = count_hetamt_2 + 1
-                        continue
-                    else:
-                        tmp_atom_dist = []
-                        for atom_1 in residue_1:
-                            if atom_1.get_name() != 'H':
-                                for atom_2 in residue_2:
-                                    if atom_2.get_name() != 'H':
-                                        calc_dist = residue_1[atom_1.get_name()] - residue_2[atom_2.get_name()]
-                                        tmp_atom_dist.append(calc_dist)
-                        # print('tmp list: %s' % tmp_atom_dist)
-                        min_atom_dist = min(tmp_atom_dist)
-                        # print(min_atom_dist)
-                        residue_dist.append(min_atom_dist)
-                # if min(residue_dist) < 6:
-                #     print(min(residue_dist))
-                min_residue_dist = min(residue_dist)
-                dist_matrix.append([
-                    index_1 + 1 - count_hetamt_1,
-                    three_to_one[residue_1.get_resname()],
-                    residue_1.id[1],
-                    min_residue_dist
-                ])
+            coords1 = self._heavy_atom_coords(residue_1)
+            residue_dist = [
+                self._min_atom_distance(coords1, coords2)
+                for _, _, _, coords2 in chain2_records
+            ]
+            min_residue_dist = min(residue_dist)
+            dist_matrix.append([
+                fasta_id_1,
+                three_to_one[residue_1.get_resname()],
+                residue_1.id[1],
+                min_residue_dist
+            ])
         return dist_matrix
 
     def one2one_all(
@@ -132,41 +137,32 @@ class distance(metaclass=ABCMeta):
         """
         console.verbose = verbose
         dist_matrix = []
-        count_hetamt_1 = 0
+        chain2_records = [
+            (
+                index_2,
+                residue_2,
+                None if residue_2.get_id()[0] != ' ' else self._heavy_atom_coords(residue_2),
+            )
+            for index_2, residue_2 in enumerate(chain2)
+        ]
         count_hetamt_2 = 0
-        for index_1, residue_1 in enumerate(chain1):
+        for index_1, fasta_id_1, residue_1 in self._standard_residue_records(chain1):
             console.print("==================>residue 1 ID: {}".format(index_1))
-            if residue_1.get_id()[0] != ' ':
-                # print(residue_1.get_id())
-                count_hetamt_1 = count_hetamt_1 + 1
-                continue
-            else:
-                # print(residue_1.get_id())
-                for index_2, residue_2 in enumerate(chain2):
-                    # console.print("=====================>residue 2 ID: {}".format(index_1))
-                    tmp_atom_dist = []
-                    if residue_2.get_id()[0] != ' ':
-                        count_hetamt_2 = count_hetamt_2 + 1
-                        continue
-                    else:
-                        for atom_1 in residue_1:
-                            if atom_1.get_name() != 'H':
-                                for atom_2 in residue_2:
-                                    if atom_2.get_name() != 'H':
-                                        calc_dist = residue_1[atom_1.get_name()] - residue_2[atom_2.get_name()]
-                                        tmp_atom_dist.append(calc_dist)
-                        # print('tmp list: %s' % tmp_atom_dist)
-                        min_dist = min(tmp_atom_dist)
-                        # print(min_dist)
-                        dist_matrix.append([
-                            index_1 + 1 - count_hetamt_1,
-                            three_to_one[residue_1.get_resname()],
-                            residue_1.id[1],
-                            index_2 + 1 - count_hetamt_2,
-                            'U' if residue_2.get_resname() == 'UNK' else three_to_one[residue_2.get_resname()],
-                            residue_2.id[1],
-                            min_dist,
-                        ])
+            coords1 = self._heavy_atom_coords(residue_1)
+            for index_2, residue_2, coords2 in chain2_records:
+                if residue_2.get_id()[0] != ' ':
+                    count_hetamt_2 += 1
+                    continue
+                min_dist = self._min_atom_distance(coords1, coords2)
+                dist_matrix.append([
+                    fasta_id_1,
+                    three_to_one[residue_1.get_resname()],
+                    residue_1.id[1],
+                    index_2 + 1 - count_hetamt_2,
+                    'U' if residue_2.get_resname() == 'UNK' else three_to_one[residue_2.get_resname()],
+                    residue_2.id[1],
+                    min_dist,
+                ])
         return dist_matrix
 
     def check(
@@ -197,31 +193,16 @@ class distance(metaclass=ABCMeta):
 
         """
         console.verbose = verbose
-        mark = False
-        for index_1, residue_1 in enumerate(chain1):
+        chain2_records = [
+            (index_2, residue_2, self._heavy_atom_coords(residue_2))
+            for index_2, _, residue_2 in self._standard_residue_records(chain2)
+        ]
+        for index_1, _, residue_1 in self._standard_residue_records(chain1):
             console.print("==================>residue 1 ID: {}".format(index_1))
-            min_check = []
-            if residue_1.get_id()[0] != ' ':
-                continue
-            else:
-                for index_2, residue_2 in enumerate(chain2):
-                    tmp_atom_dist = []
-                    if residue_2.get_id()[0] != ' ':
-                        continue
-                    else:
-                        for atom_1 in residue_1:
-                            if atom_1.get_name() != 'H':
-                                for atom_2 in residue_2:
-                                    if atom_2.get_name() != 'H':
-                                        calc_dist = residue_1[atom_1.get_name()] - residue_2[atom_2.get_name()]
-                                        tmp_atom_dist.append(calc_dist)
-                        # print('tmp list: %s' % tmp_atom_dist)
-                        min_dist = min(tmp_atom_dist)
-                        min_check.append(min_dist)
-                    if min(min_check) < thres:
-                        mark = True
-                        console.print("==================>residue {} and residue {} in interaction".format(index_1, index_2))
-                        break
-                if mark:
-                    break
-        return mark
+            coords1 = self._heavy_atom_coords(residue_1)
+            for index_2, residue_2, coords2 in chain2_records:
+                min_dist = self._min_atom_distance(coords1, coords2)
+                if min_dist < thres:
+                    console.print("==================>residue {} and residue {} in interaction".format(index_1, index_2))
+                    return True
+        return False

--- a/tests/test_alignment_frequency_optimization.py
+++ b/tests/test_alignment_frequency_optimization.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+
+from pypropel.prot.feature.alignment.frequency.Single import Single
+from pypropel.prot.sequence.Symbol import Symbol
+
+
+def legacy_columns(msa):
+    aa_alphabet = Symbol().single(gap=True, universal=False)
+    msa_row = len(msa)
+    msa_col = len(msa[0])
+    counts = {aa: [0] * msa_col for aa in aa_alphabet}
+    for homolog in msa:
+        for alignment_pos, base in enumerate(homolog):
+            if base in counts:
+                counts[base][alignment_pos] += 1
+    freq = {aa: np.array(counts[aa]) / msa_row for aa in aa_alphabet}
+    return freq, np.array(counts['-']) / msa_row
+
+
+def legacy_alignment(msa):
+    aa_alphabet = Symbol().single(gap=True, universal=False)
+    total_num_msa = len(msa) * len(msa[0])
+    counts = {aa: 0 for aa in aa_alphabet}
+    for row in msa:
+        for base in row:
+            if base in counts:
+                counts[base] += 1
+    freq_array = np.array([counts[aa] for aa in aa_alphabet]) / total_num_msa
+    return {aa: freq_array[i] for i, aa in enumerate(aa_alphabet)}
+
+
+class AlignmentFrequencyOptimizationTest(unittest.TestCase):
+    def test_columns_matches_legacy_counts(self):
+        msa = [
+            "ACD-EFX",
+            "A-DGEFY",
+            "WCD-EF-",
+            "------Z",
+        ]
+
+        expected_freq, expected_omit = legacy_columns(msa)
+        actual_freq, actual_omit = Single(msa).columns()
+
+        self.assertEqual(actual_freq.keys(), expected_freq.keys())
+        for aa in expected_freq:
+            np.testing.assert_allclose(actual_freq[aa], expected_freq[aa])
+        np.testing.assert_allclose(actual_omit, expected_omit)
+
+    def test_alignment_matches_legacy_counts(self):
+        msa = [
+            "ACD-EFX",
+            "A-DGEFY",
+            "WCD-EF-",
+            "------Z",
+        ]
+
+        expected = legacy_alignment(msa)
+        actual = Single(msa).alignment()
+
+        self.assertEqual(actual.keys(), expected.keys())
+        for aa in expected:
+            self.assertEqual(actual[aa], expected[aa])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_alignment_representation_optimization.py
+++ b/tests/test_alignment_representation_optimization.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import unittest
+from collections import Counter
+
+import numpy as np
+
+from pypropel.prot.feature.alignment.representation.Binary import Binary
+from pypropel.prot.feature.alignment.representation.Frequency import Frequency
+
+
+AA_TO_INDEX = {aa: i for i, aa in enumerate("ACDEFGHIKLMNPQRSTVWY-")}
+
+
+def legacy_onehot(msa):
+    msa_row = len(msa)
+    msa_col = len(msa[0])
+    binary_matrix = [[0 for _ in range(msa_col * 21)] for _ in range(msa_row)]
+    for i in range(msa_row):
+        for j in range(msa_col):
+            if msa[i][j] in AA_TO_INDEX:
+                binary_matrix[i][j * 21 + AA_TO_INDEX[msa[i][j]]] = 1
+    return np.array(binary_matrix)
+
+
+def legacy_calc_sgl_col(msa, x):
+    bases = [row[x] for row in msa]
+    num_total = len(bases)
+    freq_all_bases = Counter(bases).most_common()
+    freq_single = [0 for _ in range(num_total)]
+    for i in range(len(freq_all_bases)):
+        for j in range(num_total):
+            if np.array_equal(freq_all_bases[i][0], bases[j]):
+                freq_single[j] = round(freq_all_bases[i][1] / num_total, 4)
+                if bases[j] == '-':
+                    freq_single[j] = 0
+    return freq_single
+
+
+def legacy_matrix(msa):
+    return np.transpose(np.array([
+        legacy_calc_sgl_col(msa, i)
+        for i in range(len(msa[0]))
+    ]))
+
+
+class AlignmentRepresentationOptimizationTest(unittest.TestCase):
+    def test_onehot_matches_legacy(self):
+        msa = [
+            "ACD-EFX",
+            "A-DGEFY",
+            "WCD-EF-",
+        ]
+
+        np.testing.assert_array_equal(Binary(msa).onehot(), legacy_onehot(msa))
+
+    def test_frequency_column_matches_legacy(self):
+        msa = [
+            "ACD-EFX",
+            "A-DGEFY",
+            "WCD-EF-",
+        ]
+
+        self.assertEqual(Frequency(msa).calc_sgl_col(2), legacy_calc_sgl_col(msa, 2))
+
+    def test_frequency_matrix_matches_legacy(self):
+        msa = [
+            "ACD-EFX",
+            "A-DGEFY",
+            "WCD-EF-",
+        ]
+
+        np.testing.assert_allclose(Frequency(msa).matrix(), legacy_matrix(msa))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_distance_optimization.py
+++ b/tests/test_distance_optimization.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+from Bio.PDB.Atom import Atom
+from Bio.PDB.Chain import Chain
+from Bio.PDB.Residue import Residue
+
+from pypropel.prot.structure.distance.Distance import distance, three_to_one
+
+
+class ConcreteDistance(distance):
+    def calculate(self):
+        return None
+
+
+def atom(name, coord):
+    return Atom(name, np.asarray(coord, dtype=float), 1.0, 1.0, " ", name.rjust(4), 1, element=name[0])
+
+
+def residue(resname, seq_id, coords):
+    res = Residue((" ", seq_id, " "), resname, "")
+    for atom_name, coord in coords:
+        res.add(atom(atom_name, coord))
+    return res
+
+
+def hetero_residue(resname, seq_id, coords):
+    res = Residue(("H_TEST", seq_id, " "), resname, "")
+    for atom_name, coord in coords:
+        res.add(atom(atom_name, coord))
+    return res
+
+
+def chain(chain_id, residues):
+    chn = Chain(chain_id)
+    for res in residues:
+        chn.add(res)
+    return chn
+
+
+def legacy_min_distance(residue_1, residue_2):
+    tmp_atom_dist = []
+    for atom_1 in residue_1:
+        if atom_1.get_name() != "H":
+            for atom_2 in residue_2:
+                if atom_2.get_name() != "H":
+                    tmp_atom_dist.append(residue_1[atom_1.get_name()] - residue_2[atom_2.get_name()])
+    return min(tmp_atom_dist)
+
+
+def legacy_one2one_all(chain1, chain2):
+    dist_matrix = []
+    count_hetamt_1 = 0
+    count_hetamt_2 = 0
+    for index_1, residue_1 in enumerate(chain1):
+        if residue_1.get_id()[0] != " ":
+            count_hetamt_1 = count_hetamt_1 + 1
+            continue
+        for index_2, residue_2 in enumerate(chain2):
+            if residue_2.get_id()[0] != " ":
+                count_hetamt_2 = count_hetamt_2 + 1
+                continue
+            min_dist = legacy_min_distance(residue_1, residue_2)
+            dist_matrix.append([
+                index_1 + 1 - count_hetamt_1,
+                three_to_one[residue_1.get_resname()],
+                residue_1.id[1],
+                index_2 + 1 - count_hetamt_2,
+                "U" if residue_2.get_resname() == "UNK" else three_to_one[residue_2.get_resname()],
+                residue_2.id[1],
+                min_dist,
+            ])
+    return dist_matrix
+
+
+class DistanceOptimizationTest(unittest.TestCase):
+    def setUp(self):
+        self.chain1 = chain("A", [
+            residue("ALA", 1, [("N", (0.0, 0.0, 0.0)), ("CA", (1.0, 0.0, 0.0)), ("H", (99.0, 0.0, 0.0))]),
+            residue("GLY", 2, [("N", (5.0, 0.0, 0.0)), ("CA", (6.0, 0.0, 0.0))]),
+        ])
+        self.chain2 = chain("B", [
+            residue("SER", 1, [("N", (0.0, 3.0, 0.0)), ("CA", (1.0, 3.0, 0.0))]),
+            residue("VAL", 2, [("N", (8.0, 0.0, 0.0)), ("CA", (9.0, 0.0, 0.0))]),
+        ])
+        self.dist = ConcreteDistance()
+
+    def test_one2one_all_matches_legacy(self):
+        self.assertEqual(
+            self.dist.one2one_all(self.chain1, self.chain2),
+            legacy_one2one_all(self.chain1, self.chain2),
+        )
+
+    def test_one2one_all_preserves_legacy_hetero_indexing(self):
+        chain2 = chain("B", [
+            residue("SER", 1, [("N", (0.0, 3.0, 0.0))]),
+            hetero_residue("SER", 2, [("N", (99.0, 99.0, 99.0))]),
+            residue("VAL", 3, [("N", (8.0, 0.0, 0.0))]),
+        ])
+
+        self.assertEqual(
+            self.dist.one2one_all(self.chain1, chain2),
+            legacy_one2one_all(self.chain1, chain2),
+        )
+
+    def test_one2one_minimal_matches_legacy(self):
+        all_distances = legacy_one2one_all(self.chain1, self.chain2)
+        expected = [
+            [1, "A", 1, min(row[6] for row in all_distances if row[0] == 1)],
+            [2, "G", 2, min(row[6] for row in all_distances if row[0] == 2)],
+        ]
+        self.assertEqual(self.dist.one2one_minimal(self.chain1, self.chain2), expected)
+
+    def test_check_matches_legacy_threshold_behavior(self):
+        self.assertTrue(self.dist.check(self.chain1, self.chain2, thres=3.1))
+        self.assertFalse(self.dist.check(self.chain1, self.chain2, thres=1.0))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_feature_assembly_optimization.py
+++ b/tests/test_feature_assembly_optimization.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+import pandas as pd
+
+from pypropel.prot.feature.PSSM import PSSM
+from pypropel.prot.feature.rsa.Assemble import Assemble as RSAAssemble
+from pypropel.prot.feature.ss.Assemble import Assemble as SSAssemble
+
+
+class FeatureAssemblyOptimizationTest(unittest.TestCase):
+    def test_sspro8_matches_legacy_encoding(self):
+        df = pd.DataFrame([["H"], ["E"], ["S"]])
+        base = [[0], [1]]
+        window_ids = [([None, 1], [2]), ([3], [None])]
+
+        actual = SSAssemble().sspro8(df, [row[:] for row in base], window_ids)
+
+        expected = [
+            [0] + [0.0] * 8 + [0, 0, 0, 0, 0, 0, 0, 1] + [0, 0, 0, 0, 1, 0, 0, 0],
+            [1] + [0, 1, 0, 0, 0, 0, 0, 0] + [0.0] * 8,
+        ]
+        self.assertEqual(actual, expected)
+
+    def test_psipred_matches_legacy_window_append(self):
+        df = pd.DataFrame([
+            [1, "A", "H", 0.1, 0.2, 0.7],
+            [2, "C", "E", 0.3, 0.4, 0.3],
+        ])
+        actual = SSAssemble().psipred(df, [[0], [1]], [([1], [None]), ([2], [1])])
+        expected = [
+            [0, 0.1, 0.2, 0.7, 0.0, 0.0, 0.0],
+            [1, 0.3, 0.4, 0.3, 0.1, 0.2, 0.7],
+        ]
+        self.assertEqual(actual, expected)
+
+    def test_rsa_accpro20_preserves_current_mapping(self):
+        df = pd.DataFrame([[0.0], [0.2], [0.205], [0.9], [1.0]])
+        actual = RSAAssemble().accpro20(df, [[0], [1]], [[1, 2, None], [3, 4, 5]], mode="single")
+
+        def onehot(active_idx):
+            return [1 if idx == active_idx else 0 for idx in range(20)]
+
+        expected = [
+            [0] + onehot(19) + onehot(15) + [0.0] * 20,
+            [1] + onehot(2) + onehot(1) + onehot(0),
+        ]
+        self.assertEqual(actual, expected)
+
+    def test_pssm_blast_and_hhm_match_legacy_window_append(self):
+        pssm = {1: [1] * 20, 2: [2] * 20}
+        hhm = {1: np.ones(30), 2: np.ones(30) * 2}
+        window_ids = [[[None, 1], [2]], [[1]]]
+
+        actual_blast = PSSM().blast_(pssm, [[0], [1]], window_ids)
+        expected_blast = [
+            [0] + [0] * 20 + [1] * 20 + [2] * 20,
+            [1] + [1] * 20,
+        ]
+        self.assertEqual(actual_blast, expected_blast)
+
+        actual_hhm = PSSM().hhm_(hhm, [[0], [1]], window_ids)
+        expected_hhm = [
+            [0] + [0] * 30 + [1.0] * 30 + [2.0] * 30,
+            [1] + [1.0] * 30,
+        ]
+        self.assertEqual(actual_hhm, expected_hhm)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_lazy_imports.py
+++ b/tests/test_lazy_imports.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import unittest
+
+
+class LazyImportTest(unittest.TestCase):
+    def test_pypropel_import_does_not_eagerly_import_plot_stack(self):
+        for module_name in [
+            "pypropel",
+            "pypropel.plot",
+            "matplotlib",
+            "matplotlib.pyplot",
+            "seaborn",
+        ]:
+            sys.modules.pop(module_name, None)
+
+        pypropel = importlib.import_module("pypropel")
+
+        self.assertNotIn("pypropel.plot", sys.modules)
+        self.assertNotIn("matplotlib.pyplot", sys.modules)
+        self.assertEqual(pypropel.msa.__name__, "pypropel.msa")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Vectorize MSA column/alignment frequency counting and MSA one-hot/frequency representations.
- Reduce residue-distance atom-pair loop overhead with NumPy coordinate blocks while preserving existing output behavior.
- Reduce repeated list concatenation in feature assembly paths.
- Lazy-load public PyPropel wrapper modules so plotting dependencies are not imported on plain package import.
- Add focused behavior tests and benchmark scripts for the optimized paths.

## Validation

- `/Users/zhaoj/Project/TMInter/.venv/bin/python -m unittest discover -s tests`
- Performance worktree result: `Ran 14 tests ... OK`

## Benchmarks

Representative local benchmark results from the TMInter environment:

- Alignment columns: `0.300489s -> 0.018815s`
- Alignment whole frequency: `0.333040s -> 0.032574s`
- MSA one-hot: `0.565160s -> 0.001411s`
- MSA frequency matrix: `10.563461s -> 0.012403s`
- Distance `one2one_all`: `0.024435s -> 0.004458s`
- Feature assembly `solvpred`: `0.003100s -> 0.001815s`
- Feature assembly `blast_`: `0.041790s -> 0.009975s`

Created as a draft for maintainer review.