### PR TITLE
[codex] Add optional ESM embedding helpers

### DIFF
--- a/docs/tutorial/protein/feature/esm.md
+++ b/docs/tutorial/protein/feature/esm.md
@@ -1,0 +1,78 @@
+ESM2 embeddings are protein language model representations for amino acid sequences. PyPropel exposes them as an optional feature extraction module because the runtime depends on large model weights and PyTorch.
+
+Install the optional dependencies before extracting embeddings.
+
+:material-console: Shell
+``` shell
+pip install "pypropel[esm]"
+```
+
+### Availability
+
+:material-language-python: Python
+``` py linenums="1"
+import pypropel as pp
+
+print(pp.esm.is_available())
+```
+
+### Single sequence
+
+:material-language-python: Python
+``` py linenums="1"
+import pypropel as pp
+
+sequence = "MVLSPADKTNVKAAW"
+embedding = pp.esm.embed_sequence(
+    sequence=sequence,
+    model_name="esm2_t33_650M_UR50D",
+    device="cuda:0",
+    layer=-1,
+)
+print(embedding.shape)
+```
+
+The returned array has one row per residue. Its column count depends on the selected ESM2 model.
+
+### Batch extraction
+
+:material-language-python: Python
+``` py linenums="1"
+import pypropel as pp
+
+sequences = ["MVLSPADKTNVKAAW", "ACDEFGHIKLMNPQ"]
+embeddings = pp.esm.embed_batch(
+    sequences=sequences,
+    model_name="esm2_t12_35M_UR50D",
+    batch_size=4,
+)
+```
+
+### Cache embeddings
+
+:material-language-python: Python
+``` py linenums="1"
+import pypropel as pp
+
+sequence = "MVLSPADKTNVKAAW"
+embedding = pp.esm.embed_sequence(sequence)
+metadata = pp.esm.build_metadata(
+    sequence=sequence,
+    embedding=embedding,
+    model_name="esm2_t33_650M_UR50D",
+    layer=-1,
+)
+
+pp.esm.save_embeddings(
+    embeddings=embedding,
+    filepath="protein_esm2.npz",
+    metadata=metadata,
+)
+
+loaded, loaded_metadata = pp.esm.load_embeddings(
+    "protein_esm2.npz",
+    include_metadata=True,
+)
+```
+
+Record the model name, layer, sequence hash, cache path, and checksum in downstream experiment run records when embeddings are used as model features.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,11 @@ matplotlib = "^3.9.1"
 scikit-learn = "^1.5.1"
 mini3di = "^0.2.1"
 click = "^8.2.1"
+torch = { version = ">=2.0.0", optional = true }
+fair-esm = { version = ">=2.0.0", optional = true }
+
+[tool.poetry.extras]
+esm = ["torch", "fair-esm"]
 
 [tool.poetry.scripts]
 pypropel_struct_check_cplx = "pypropel.prot.structure.distance.isite.check.Complex:cli"

--- a/pypropel/__init__.py
+++ b/pypropel/__init__.py
@@ -17,4 +17,5 @@ from . import (
     seq,
     str,
     uniprot,
+    esm,
 )

--- a/pypropel/esm.py
+++ b/pypropel/esm.py
@@ -1,0 +1,314 @@
+from __future__ import annotations
+
+__version__ = "v1.0"
+__copyright__ = "Copyright 2024"
+__license__ = "GPL v3.0"
+__developer__ = "Jianfeng Sun"
+__maintainer__ = "Jianfeng Sun"
+__email__ = "jianfeng.sunmt@gmail.com"
+
+import hashlib
+import importlib
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, Union
+
+import numpy as np
+
+DEFAULT_MODEL_NAME = "esm2_t33_650M_UR50D"
+DEFAULT_LAYER = -1
+VALID_SEQUENCE_SYMBOLS = frozenset("ACDEFGHIKLMNPQRSTVWYBXZUO")
+METADATA_KEY = "__metadata_json__"
+
+_MODEL_CACHE: Dict[Tuple[str, str], Tuple[Any, Any, Any]] = {}
+
+
+def is_available() -> bool:
+    """Return True when the optional torch and fair-esm dependencies import."""
+    try:
+        _import_optional_dependencies()
+    except ImportError:
+        return False
+    return True
+
+
+def clear_model_cache() -> None:
+    """Clear cached ESM model instances."""
+    _MODEL_CACHE.clear()
+
+
+def load_model(
+    model_name: str = DEFAULT_MODEL_NAME,
+    device: str = "cpu",
+    use_cache: bool = True,
+) -> Tuple[Any, Any, Any]:
+    """
+    Load an ESM model, alphabet, and batch converter.
+
+    Parameters
+    ----------
+    model_name
+        Name understood by ``esm.pretrained.load_model_and_alphabet``.
+    device
+        Torch device string, for example ``cpu`` or ``cuda:0``.
+    use_cache
+        If True, reuse a model cached by ``(model_name, device)``.
+    """
+    _, esm_lib = _import_optional_dependencies()
+    cache_key = (model_name, str(device))
+    if use_cache and cache_key in _MODEL_CACHE:
+        return _MODEL_CACHE[cache_key]
+
+    model, alphabet = esm_lib.pretrained.load_model_and_alphabet(model_name)
+    if hasattr(model, "eval"):
+        model.eval()
+    if device is not None and hasattr(model, "to"):
+        model = model.to(device)
+    batch_converter = alphabet.get_batch_converter()
+    loaded = (model, alphabet, batch_converter)
+    if use_cache:
+        _MODEL_CACHE[cache_key] = loaded
+    return loaded
+
+
+def embed_sequence(
+    sequence: str,
+    model_name: str = DEFAULT_MODEL_NAME,
+    device: str = "cpu",
+    layer: int = DEFAULT_LAYER,
+    model: Any = None,
+    alphabet: Any = None,
+    batch_converter: Any = None,
+) -> np.ndarray:
+    """
+    Extract per-residue ESM embeddings for one protein sequence.
+
+    The returned array has one row per residue in ``sequence``. The embedding
+    dimension depends on the selected ESM model.
+    """
+    return embed_batch(
+        [sequence],
+        model_name=model_name,
+        device=device,
+        layer=layer,
+        model=model,
+        alphabet=alphabet,
+        batch_converter=batch_converter,
+    )[0]
+
+
+def embed_batch(
+    sequences: Sequence[str],
+    model_name: str = DEFAULT_MODEL_NAME,
+    device: str = "cpu",
+    layer: int = DEFAULT_LAYER,
+    batch_size: int = 8,
+    model: Any = None,
+    alphabet: Any = None,
+    batch_converter: Any = None,
+) -> List[np.ndarray]:
+    """
+    Extract per-residue ESM embeddings for multiple protein sequences.
+
+    Parameters
+    ----------
+    sequences
+        Protein sequences using one-letter amino acid symbols.
+    model_name
+        ESM model name used when ``model`` is not supplied.
+    device
+        Torch device string.
+    layer
+        Representation layer. Negative values follow Python-style indexing
+        over model layers, so ``-1`` means the last layer.
+    batch_size
+        Number of sequences per model call.
+    model, alphabet, batch_converter
+        Optional preloaded ESM runtime objects. If ``model`` is supplied,
+        provide either ``batch_converter`` or ``alphabet`` so no implicit
+        model load is needed.
+    """
+    if batch_size < 1:
+        raise ValueError("batch_size must be at least 1")
+    normalized = [normalize_sequence(seq) for seq in sequences]
+    if not normalized:
+        return []
+
+    torch, _ = _import_optional_dependencies()
+    model, alphabet, batch_converter = _resolve_runtime(
+        model_name=model_name,
+        device=device,
+        model=model,
+        alphabet=alphabet,
+        batch_converter=batch_converter,
+    )
+    layer_idx = resolve_layer(model, layer)
+
+    embeddings: List[np.ndarray] = []
+    for batch_start in range(0, len(normalized), batch_size):
+        batch_sequences = normalized[batch_start : batch_start + batch_size]
+        batch_data = [
+            (f"sequence_{batch_start + offset}", seq)
+            for offset, seq in enumerate(batch_sequences)
+        ]
+        _, _, batch_tokens = batch_converter(batch_data)
+        if device is not None and hasattr(batch_tokens, "to"):
+            batch_tokens = batch_tokens.to(device)
+
+        with torch.no_grad():
+            result = model(batch_tokens, repr_layers=[layer_idx])
+
+        representations = result["representations"][layer_idx]
+        for batch_index, seq in enumerate(batch_sequences):
+            arr = _to_numpy(representations[batch_index, 1 : len(seq) + 1])
+            arr = np.asarray(arr, dtype=np.float32)
+            validate_embedding_alignment(arr, seq)
+            embeddings.append(arr)
+    return embeddings
+
+
+def save_embeddings(
+    embeddings: Union[np.ndarray, Mapping[str, np.ndarray]],
+    filepath: Union[str, Path],
+    metadata: Optional[Mapping[str, Any]] = None,
+) -> None:
+    """
+    Save embeddings to a compressed ``.npz`` file with optional JSON metadata.
+    """
+    payload: Dict[str, Any]
+    if isinstance(embeddings, np.ndarray):
+        payload = {"embeddings": embeddings}
+    else:
+        payload = {str(key): np.asarray(value) for key, value in embeddings.items()}
+    if metadata is not None:
+        payload[METADATA_KEY] = np.asarray(json.dumps(dict(metadata), sort_keys=True))
+    np.savez_compressed(filepath, **payload)
+
+
+def load_embeddings(
+    filepath: Union[str, Path],
+    include_metadata: bool = False,
+) -> Union[Dict[str, np.ndarray], Tuple[Dict[str, np.ndarray], Dict[str, Any]]]:
+    """
+    Load embeddings from a compressed ``.npz`` file.
+    """
+    with np.load(filepath, allow_pickle=False) as data:
+        embeddings = {
+            key: data[key]
+            for key in data.files
+            if key != METADATA_KEY
+        }
+        metadata: Dict[str, Any] = {}
+        if METADATA_KEY in data.files:
+            metadata = json.loads(str(data[METADATA_KEY].item()))
+    if include_metadata:
+        return embeddings, metadata
+    return embeddings
+
+
+def build_metadata(
+    sequence: str,
+    embedding: Optional[np.ndarray] = None,
+    model_name: str = DEFAULT_MODEL_NAME,
+    layer: int = DEFAULT_LAYER,
+    extra: Optional[Mapping[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Build reproducibility metadata for a sequence embedding artifact."""
+    normalized = normalize_sequence(sequence)
+    metadata: Dict[str, Any] = {
+        "model_name": model_name,
+        "layer": int(layer),
+        "sequence_length": len(normalized),
+        "sequence_sha256": hashlib.sha256(normalized.encode("utf-8")).hexdigest(),
+    }
+    if embedding is not None:
+        arr = np.asarray(embedding)
+        metadata["embedding_shape"] = list(arr.shape)
+        metadata["embedding_dtype"] = str(arr.dtype)
+    if extra:
+        metadata.update(dict(extra))
+    return metadata
+
+
+def normalize_sequence(sequence: str) -> str:
+    """Normalize and validate a one-letter protein sequence."""
+    if not isinstance(sequence, str):
+        raise TypeError("sequence must be a string")
+    normalized = "".join(sequence.split()).upper()
+    if not normalized:
+        raise ValueError("sequence must not be empty")
+    invalid = sorted(set(normalized) - VALID_SEQUENCE_SYMBOLS)
+    if invalid:
+        raise ValueError(f"sequence contains unsupported symbols: {''.join(invalid)}")
+    return normalized
+
+
+def validate_embedding_alignment(embedding: np.ndarray, sequence: str) -> None:
+    """Raise if an embedding array does not have one row per residue."""
+    normalized = normalize_sequence(sequence)
+    arr = np.asarray(embedding)
+    if arr.ndim != 2:
+        raise ValueError("embedding must be a 2D array")
+    if arr.shape[0] != len(normalized):
+        raise ValueError(
+            f"embedding row count {arr.shape[0]} does not match sequence length {len(normalized)}"
+        )
+
+
+def resolve_layer(model: Any, layer: int) -> int:
+    """Resolve a requested representation layer against an ESM model."""
+    if not isinstance(layer, int):
+        raise TypeError("layer must be an integer")
+    num_layers = getattr(model, "num_layers", None)
+    if num_layers is None:
+        if layer < 0:
+            raise ValueError("negative layer values require model.num_layers")
+        return layer
+    resolved = num_layers + 1 + layer if layer < 0 else layer
+    if resolved < 0 or resolved > num_layers:
+        raise ValueError(f"layer {layer} resolves outside available layers 0..{num_layers}")
+    return int(resolved)
+
+
+def _resolve_runtime(
+    model_name: str,
+    device: str,
+    model: Any = None,
+    alphabet: Any = None,
+    batch_converter: Any = None,
+) -> Tuple[Any, Any, Any]:
+    if model is None:
+        return load_model(model_name=model_name, device=device)
+    if batch_converter is None:
+        if alphabet is None:
+            raise ValueError("alphabet or batch_converter is required when model is supplied")
+        batch_converter = alphabet.get_batch_converter()
+    return model, alphabet, batch_converter
+
+
+def _import_optional_dependencies() -> Tuple[Any, Any]:
+    try:
+        torch = importlib.import_module("torch")
+        esm_lib = importlib.import_module("esm")
+    except ImportError as exc:
+        raise ImportError(
+            "ESM embedding support requires optional dependencies. "
+            "Install them with: pip install 'pypropel[esm]'"
+        ) from exc
+    return torch, esm_lib
+
+
+def _to_numpy(value: Any) -> np.ndarray:
+    if hasattr(value, "detach"):
+        value = value.detach()
+    if hasattr(value, "cpu"):
+        value = value.cpu()
+    if hasattr(value, "numpy"):
+        value = value.numpy()
+    return np.asarray(value)
+
+
+# Backward-compatible aliases matching common ESM wrapper naming.
+load_esm_model = load_model
+get_esm_embeddings = embed_sequence
+get_esm_embeddings_batch = embed_batch

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,12 @@ setup(
         'mini3di',
         # 'pyfiglet', # ==0.8.post1
     ],
+    extras_require={
+        'esm': [
+            'torch>=2.0.0',
+            'fair-esm>=2.0.0',
+        ],
+    },
     entry_points={
         'console_scripts': [
             'pypropel=pypropel.main:main',

--- a/tests/test_esm.py
+++ b/tests/test_esm.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import numpy as np
+
+from pypropel import esm
+
+
+class FakeNoGrad:
+    def __enter__(self):
+        return None
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class FakeTokens:
+    def __init__(self, sequences):
+        self.sequences = sequences
+        self.device = "cpu"
+
+    def to(self, device):
+        self.device = device
+        return self
+
+
+class FakeArray:
+    def __init__(self, values):
+        self.values = np.asarray(values, dtype=np.float32)
+
+    def __getitem__(self, item):
+        return FakeArray(self.values[item])
+
+    def cpu(self):
+        return self
+
+    def numpy(self):
+        return self.values
+
+
+class FakeModel:
+    num_layers = 2
+
+    def __init__(self, name="fake"):
+        self.name = name
+        self.device = "cpu"
+        self.eval_called = False
+
+    def eval(self):
+        self.eval_called = True
+        return self
+
+    def to(self, device):
+        self.device = device
+        return self
+
+    def __call__(self, batch_tokens, repr_layers):
+        layer = repr_layers[0]
+        dim = 3
+        max_len = max(len(seq) for seq in batch_tokens.sequences) + 2
+        values = np.zeros((len(batch_tokens.sequences), max_len, dim), dtype=np.float32)
+        for batch_idx, sequence in enumerate(batch_tokens.sequences):
+            for residue_idx, symbol in enumerate(sequence, start=1):
+                values[batch_idx, residue_idx, :] = [
+                    float(layer),
+                    float(residue_idx),
+                    float(ord(symbol)),
+                ]
+        return {"representations": {layer: FakeArray(values)}}
+
+
+class FakeAlphabet:
+    def get_batch_converter(self):
+        def convert(data):
+            sequences = [sequence for _, sequence in data]
+            return None, None, FakeTokens(sequences)
+
+        return convert
+
+
+class FakePretrained:
+    def __init__(self):
+        self.loads = []
+
+    def load_model_and_alphabet(self, model_name):
+        self.loads.append(model_name)
+        return FakeModel(model_name), FakeAlphabet()
+
+
+class ESMTest(unittest.TestCase):
+    def setUp(self):
+        esm.clear_model_cache()
+
+    def tearDown(self):
+        esm.clear_model_cache()
+
+    def test_is_available_false_when_optional_import_fails(self):
+        with mock.patch("importlib.import_module", side_effect=ImportError("missing")):
+            self.assertFalse(esm.is_available())
+
+    def test_load_model_cache_is_keyed_by_model_and_device(self):
+        with self.fake_dependencies() as fake_pretrained:
+            model_a, _, _ = esm.load_model("esm2_a", device="cpu")
+            model_b, _, _ = esm.load_model("esm2_b", device="cpu")
+            model_a_again, _, _ = esm.load_model("esm2_a", device="cpu")
+
+        self.assertIs(model_a, model_a_again)
+        self.assertIsNot(model_a, model_b)
+        self.assertEqual(fake_pretrained.loads, ["esm2_a", "esm2_b"])
+        self.assertTrue(model_a.eval_called)
+
+    def test_embed_sequence_uses_supplied_model_without_loading_default(self):
+        with self.fake_dependencies() as fake_pretrained:
+            model = FakeModel()
+            converter = FakeAlphabet().get_batch_converter()
+            embedding = esm.embed_sequence(
+                "ACD",
+                model=model,
+                batch_converter=converter,
+                layer=-1,
+            )
+
+        self.assertEqual(fake_pretrained.loads, [])
+        self.assertEqual(embedding.shape, (3, 3))
+        self.assertTrue(np.all(embedding[:, 0] == 2.0))
+
+    def test_embed_batch_returns_one_array_per_sequence(self):
+        with self.fake_dependencies():
+            embeddings = esm.embed_batch(["AC", "WXYZ"], model_name="esm2_a", batch_size=1)
+
+        self.assertEqual([arr.shape for arr in embeddings], [(2, 3), (4, 3)])
+        self.assertEqual(float(embeddings[1][0, 2]), float(ord("W")))
+
+    def test_validation_rejects_bad_sequence_and_alignment(self):
+        with self.assertRaises(ValueError):
+            esm.normalize_sequence("ACD-")
+        with self.assertRaises(ValueError):
+            esm.validate_embedding_alignment(np.zeros((2, 3)), "ACD")
+
+    def test_save_and_load_embeddings_with_metadata(self):
+        embedding = np.ones((2, 3), dtype=np.float32)
+        metadata = esm.build_metadata("AC", embedding, model_name="esm2_a", layer=-1)
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "embedding.npz"
+            esm.save_embeddings(embedding, path, metadata=metadata)
+            loaded, loaded_metadata = esm.load_embeddings(path, include_metadata=True)
+
+        self.assertTrue(np.array_equal(loaded["embeddings"], embedding))
+        self.assertEqual(loaded_metadata["model_name"], "esm2_a")
+        self.assertEqual(loaded_metadata["sequence_length"], 2)
+
+    def fake_dependencies(self):
+        return FakeDependencyContext()
+
+
+class FakeDependencyContext:
+    def __enter__(self):
+        self.old_torch = sys.modules.get("torch")
+        self.old_esm = sys.modules.get("esm")
+        self.fake_pretrained = FakePretrained()
+        fake_torch = types.SimpleNamespace(no_grad=lambda: FakeNoGrad())
+        fake_esm = types.SimpleNamespace(pretrained=self.fake_pretrained)
+        sys.modules["torch"] = fake_torch
+        sys.modules["esm"] = fake_esm
+        importlib.invalidate_caches()
+        return self.fake_pretrained
+
+    def __exit__(self, exc_type, exc, tb):
+        if self.old_torch is None:
+            sys.modules.pop("torch", None)
+        else:
+            sys.modules["torch"] = self.old_torch
+        if self.old_esm is None:
+            sys.modules.pop("esm", None)
+        else:
+            sys.modules["esm"] = self.old_esm
+        importlib.invalidate_caches()
+        return False
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add `pypropel.esm` helpers for optional ESM model loading, sequence embedding, batch embedding, metadata, and NPZ save/load workflows.
- Expose the ESM helper module through the public package namespace.
- Add optional Poetry/setuptools extras for `torch` and `fair-esm`.
- Add documentation for ESM embedding usage.
- Add tests using fake torch/esm dependencies so the optional heavy packages are not required for the test suite.

## Validation

- `/Users/zhaoj/Project/TMInter/.venv/bin/python -m unittest discover -s tests`
- ESM worktree result: `Ran 6 tests ... OK`

Created as a draft for maintainer review.